### PR TITLE
Fixed deprecation warnings on FFmpeg 4.4

### DIFF
--- a/c_src/membrane_h264_ffmpeg_plugin/decoder.c
+++ b/c_src/membrane_h264_ffmpeg_plugin/decoder.c
@@ -98,7 +98,6 @@ UNIFEX_TERM decode(UnifexEnv *env, UnifexPayload *payload, int64_t dts, State *s
   UnifexPayload **out_frames = NULL;
   int64_t *best_effort_timestamps = NULL;
   pkt = av_packet_alloc();
-  av_init_packet(pkt);
   pkt->data = payload->data;
   pkt->size = payload->size;
   pkt->dts = dts;

--- a/c_src/membrane_h264_ffmpeg_plugin/parser.c
+++ b/c_src/membrane_h264_ffmpeg_plugin/parser.c
@@ -72,7 +72,6 @@ UNIFEX_TERM parse(UnifexEnv *env, UnifexPayload *payload, State *state) {
   memset(payload->data + old_size, 0, AV_INPUT_BUFFER_PADDING_SIZE);
 
   pkt = av_packet_alloc();
-  av_init_packet(pkt);
 
   uint8_t *data_ptr = payload->data;
   size_t data_left = old_size;


### PR DESCRIPTION
the deprecated av_init_packet(pkt) wasn't needed in the first place and can be safely removed
Closes #26 