### PR TITLE
Fixes for `skip_until_parameters?` and others

### DIFF
--- a/lib/membrane_h264_ffmpeg/parser.ex
+++ b/lib/membrane_h264_ffmpeg/parser.ex
@@ -218,7 +218,7 @@ defmodule Membrane.H264.FFmpeg.Parser do
     end
   end
 
-  # analize resolution changes and generate appropriate caps before corresponding buffers
+  # analyze resolution changes and generate appropriate caps before corresponding buffers
   defp parse_resolution_changes(state, bufs, resolution_changes, acc \\ [], index_offset \\ 0)
 
   defp parse_resolution_changes(state, [], [], [], _index_offset) do

--- a/lib/membrane_h264_ffmpeg/parser/nalu.ex
+++ b/lib/membrane_h264_ffmpeg/parser/nalu.ex
@@ -53,9 +53,10 @@ defmodule Membrane.H264.FFmpeg.Parser.NALu do
   end
 
   defp extract_nalus(access_unit, options) do
-    if Keyword.get(options, :complete_nalu?, false),
-      do: access_unit <> <<0, 0, 1>>,
-      else: access_unit
+    access_unit =
+      if Keyword.get(options, :complete_nalu?, false),
+        do: access_unit <> <<0, 0, 1>>,
+        else: access_unit
 
     access_unit
     |> :binary.matches([<<0, 0, 0, 1>>, <<0, 0, 1>>])

--- a/lib/membrane_h264_ffmpeg/parser/nalu.ex
+++ b/lib/membrane_h264_ffmpeg/parser/nalu.ex
@@ -31,7 +31,15 @@ defmodule Membrane.H264.FFmpeg.Parser.NALu do
               end)
               |> Map.new()
 
-  @spec parse(binary, keyword()) :: {list, %{h264: any}, binary}
+  @typedoc """
+  Type representing a single option that can be passed to `parse/2` function call
+
+  - `complete_nalu?` - determines if the last NALu in the binary will be considered complete despite lacking the delimiter marking the end of it.
+  """
+  @type parse_option_t() :: {:complete_nalu?, boolean()}
+  @type parse_options_t() :: [parse_option_t()]
+
+  @spec parse(binary, parse_options_t()) :: {list, %{h264: any}, binary}
   def parse(access_unit, options \\ []) do
     {nalus, au_info} =
       access_unit


### PR DESCRIPTION
This Pull Request aims to fix the bugs introduced in release `0.21.2`, namely, the tendency of some of the options to skip the entire stream while waiting for SPS and PPS, or the keyframe
