### PR TITLE
Fix wrong timestamps of the first buffer

### DIFF
--- a/lib/membrane_h264_ffmpeg/parser.ex
+++ b/lib/membrane_h264_ffmpeg/parser.ex
@@ -14,9 +14,9 @@ defmodule Membrane.H264.FFmpeg.Parser do
   and `attach_nalus?` options for details.
 
   This Parser is also capable of handling out-of-band parameters in the form of Decoder Configuration Record.
-  To inject it, simply send `t:Membrane.H264.RemoteStream` caps containing to this element.
+  To inject it, simply send `t:Membrane.H264.RemoteStream.t/0` caps containing to this element.
   There are however some limitations:
-  - `t:Membrane.H264.RemoteStream` caps need to be send only before the first buffer.
+  - `t:Membrane.H264.RemoteStream.t/0` caps need to be send only before the first buffer.
     Sending them during the stream will cause an error
   - SPS and PPS will be extracted from Decoder Configuration Record and added to the payload of the very first buffer without any checks of in-band parameters.
     This might result in duplicated SPS and PPS. It shouldn't be a problem, unless you send an incorrect Decoder Configuration Record that doesn't match the stream.
@@ -44,7 +44,7 @@ defmodule Membrane.H264.FFmpeg.Parser do
                 spec: H264.framerate_t() | nil,
                 default: nil,
                 description: """
-                Framerate of video stream, see `t:Membrane.Caps.Video.H264.framerate_t/0`
+                Framerate of video stream, see `t:Membrane.H264.framerate_t/0`
                 """
               ],
               sps: [
@@ -68,7 +68,7 @@ defmodule Membrane.H264.FFmpeg.Parser do
                 spec: :au | :nal,
                 default: :au,
                 description: """
-                Stream units carried by each output buffer. See `t:Membrane.Caps.Video.H264.alignment_t`.
+                Stream units carried by each output buffer. See `t:Membrane.H264.alignment_t/0`.
 
                 If alignment is `:nal`, the following metadata entries are added:
                 - `type` - h264 nalu type
@@ -83,7 +83,7 @@ defmodule Membrane.H264.FFmpeg.Parser do
                 default: false,
                 description: """
                 Determines whether to attach NAL units list to the metadata when `alignment` option
-                is set to `:au`. For details see `t:Membrane.Caps.Video.H264.nalu_in_metadata_t/0`.
+                is set to `:au`. For details see `t:Membrane.H264.nalu_in_metadata_t/0`.
                 """
               ],
               skip_until_keyframe?: [

--- a/lib/membrane_h264_ffmpeg/parser.ex
+++ b/lib/membrane_h264_ffmpeg/parser.ex
@@ -14,7 +14,7 @@ defmodule Membrane.H264.FFmpeg.Parser do
   and `attach_nalus?` options for details.
 
   This Parser is also capable of handling out-of-band parameters in the form of Decoder Configuration Record.
-  To inject it, simply send `t:Membrane.H264.RemoteStream.t/0` caps containing to this element.
+  To inject it, simply send `t:Membrane.H264.RemoteStream.t/0` caps containing the Decoder Configuration Record to this element.
   There are however some limitations:
   - `t:Membrane.H264.RemoteStream.t/0` caps need to be send only before the first buffer.
     Sending them during the stream will cause an error

--- a/lib/membrane_h264_ffmpeg/parser.ex
+++ b/lib/membrane_h264_ffmpeg/parser.ex
@@ -12,6 +12,14 @@ defmodule Membrane.H264.FFmpeg.Parser do
 
   Setting custom packetization options affects metadata, see `alignment`
   and `attach_nalus?` options for details.
+
+  This Parser is also capable of handling out-of-band parameters in the form of Decoder Configuration Record.
+  To inject it, simply send `t:Membrane.H264.RemoteStream` caps containing to this element.
+  There are however some limitations:
+  - `t:Membrane.H264.RemoteStream` caps need to be send only before the first buffer.
+    Sending them during the stream will cause an error
+  - SPS and PPS will be extracted from Decoder Configuration Record and added to the payload of the very first buffer without any checks of in-band parameters.
+    This might result in duplicated SPS and PPS. It shouldn't be a problem, unless you send an incorrect Decoder Configuration Record that doesn't match the stream.
   """
   use Membrane.Filter
   use Bunch

--- a/lib/membrane_h264_ffmpeg/parser.ex
+++ b/lib/membrane_h264_ffmpeg/parser.ex
@@ -22,10 +22,6 @@ defmodule Membrane.H264.FFmpeg.Parser do
   alias Membrane.Buffer
   alias Membrane.H264
 
-  @required_parameter_nalus [:pps, :sps]
-
-  defguardp is_allowed_before_data(nalu) when nalu in [:aud, :sei, :pps, :sps]
-
   def_input_pad :input,
     demand_unit: :buffers,
     demand_mode: :auto,
@@ -175,24 +171,8 @@ defmodule Membrane.H264.FFmpeg.Parser do
   # If there is a frame prefix to be applied, check that there are no in-band parameters and write the prefix if necessary
   @impl true
   def handle_process(:input, %Buffer{} = buffer, _ctx, state) when state.frame_prefix != <<>> do
-    payload = state.partial_frame <> buffer.payload
-
-    case carries_parameters_in_band?(payload) do
-      {:ok, carries_params?} ->
-        payload =
-          if carries_params?,
-            # If the stream carries parameters in-band, don't add the frame prefix. In-band parameters take priority
-            do: payload,
-            # Frame appeared without SPS and PPS, we need to insert them
-            else: state.frame_prefix <> payload
-
-        buffer = %Buffer{buffer | payload: payload}
-        # Frame prefix can always be discarded - we either inserted it or we don't need it at all
-        do_process(buffer, %{state | frame_prefix: <<>>, partial_frame: <<>>})
-
-      {:error, :not_enough_data} ->
-        {:ok, %{state | partial_frame: payload}}
-    end
+    buffer = Map.update!(buffer, :payload, &(state.frame_prefix <> &1))
+    do_process(buffer, %{state | frame_prefix: <<>>})
   end
 
   defp do_process(%Buffer{payload: payload} = buffer, state) do
@@ -273,6 +253,11 @@ defmodule Membrane.H264.FFmpeg.Parser do
       caps ++ buffers_before_change ++ pending_caps ++ acc
     )
   end
+
+  @impl true
+  def handle_caps(:input, %Membrane.H264.RemoteStream{}, ctx, _state)
+      when ctx.pads.input.start_of_stream?,
+      do: raise("Cannot send Membrane.H264.RemoteStream caps after the stream has started")
 
   @impl true
   def handle_caps(:input, %Membrane.H264.RemoteStream{} = caps, _ctx, state) do
@@ -498,38 +483,6 @@ defmodule Membrane.H264.FFmpeg.Parser do
       stream_format: :byte_stream,
       profile: profile
     }
-  end
-
-  # Checks if the required parameter NALus (see @required_parameter_nalus) are present in-band before any video frames appear
-  defp carries_parameters_in_band?(payload) do
-    types =
-      payload
-      |> NALu.parse()
-      |> elem(0)
-      |> Enum.map(& &1.metadata.h264.type)
-
-    # Split NALus parsed from the payload into two sections: parameters and data.
-    # If data appears before required parameters, this would cause an error in FFmpeg,
-    # so we identify the stream as not carrying parameters in-band.
-    # In such a case, they will be inserted into the stream before parsing,
-    # assuming that H264.RemoteStream caps providing them are present
-    {parameter_nalus, data_nalus} = Enum.split_while(types, &is_allowed_before_data/1)
-
-    parameter_nalus_set = MapSet.new(parameter_nalus)
-
-    has_required_parameters? =
-      @required_parameter_nalus |> Enum.all?(&MapSet.member?(parameter_nalus_set, &1))
-
-    cond do
-      has_required_parameters? ->
-        {:ok, true}
-
-      data_nalus == [] ->
-        {:error, :not_enough_data}
-
-      true ->
-        {:ok, false}
-    end
   end
 
   defp find_parameters(data, looking_for \\ [:sps, :pps])

--- a/test/parser/parser_integration_test.exs
+++ b/test/parser/parser_integration_test.exs
@@ -9,7 +9,6 @@ defmodule Membrane.H264.FFmpeg.Parser.IntegrationTest do
   @fixtures_dir "./test/fixtures/"
   @tmp_dir "./tmp/ParserTest/"
   @no_params_stream File.read!("test/fixtures/input-10-no-pps-sps.h264")
-  @stream_with_params File.read!("test/fixtures/input-10-720p.h264")
   @stream_with_params_change File.read!("test/fixtures/input-sps-pps-non-idr-sps-pps-idr.h264")
   @input_caps %Membrane.H264.RemoteStream{
     decoder_configuration_record:
@@ -47,18 +46,6 @@ defmodule Membrane.H264.FFmpeg.Parser.IntegrationTest do
 
     Testing.Pipeline.terminate(pipeline, blocking?: true)
     assert_pipeline_playback_changed(pipeline, :prepared, :stopped)
-  end
-
-  test "if it won't add parameters at the beginning if they are present in the input file" do
-    {input_chunks, rem_chunk} = Bunch.Binary.chunk_every_rem(@stream_with_params, 1024)
-    output_file = Path.join(@tmp_dir, "output1.h264")
-    reference_file = Path.join(@fixtures_dir, "input-10-720p.h264")
-
-    {:ok, pipeline} =
-      create_pipeline(input_chunks ++ [rem_chunk], output_file, false)
-      |> Testing.Pipeline.start_link()
-
-    play_and_validate(pipeline, reference_file, output_file)
   end
 
   test "if it will turn off the skip_until_parameters? option if the RemoteStream caps are provided" do

--- a/test/parser/parser_test.exs
+++ b/test/parser/parser_test.exs
@@ -47,7 +47,7 @@ defmodule Membrane.H264.FFmpeg.Parser.Test do
     state = init_pipeline()
     <<payload1::binary-size(5), payload2::binary>> = @no_params_stream
 
-    assert {:ok, new_state} =
+    assert {{:ok, []}, new_state} =
              Parser.handle_process(:input, %Buffer{payload: payload1}, nil, state)
 
     assert {{:ok, actions}, %{frame_prefix: <<>>}} =


### PR DESCRIPTION
This Pull Request simplifies the way we handle `Membrane.H264.RemoteStream` caps.
The insertion of new parametrs no longer aims to be "smart", as this approach was causing a lot of trouble without any real returns.
In this new version, new parameters will always be added to the payload of the very first buffer.

This change also forced us to ban sending `Membrane.H264.RemoteStream` caps in the middle of the stream.
