### PR TITLE
Update bunch to 1.4. Lock it to minor. Bump version to 0.22.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation is available at [HexDocs](https://hexdocs.pm/membrane_h264_ffmpeg_
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-  {:membrane_h264_ffmpeg_plugin, "~> 0.23.0"}
+  {:membrane_h264_ffmpeg_plugin, "~> 0.22.1"}
 ```
 
 You also need to have [ffmpeg](https://www.ffmpeg.org) libraries installed in your system.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation is available at [HexDocs](https://hexdocs.pm/membrane_h264_ffmpeg_
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-  {:membrane_h264_ffmpeg_plugin, "~> 0.22.0"}
+  {:membrane_h264_ffmpeg_plugin, "~> 0.23.0"}
 ```
 
 You also need to have [ffmpeg](https://www.ffmpeg.org) libraries installed in your system.

--- a/lib/membrane_h264_ffmpeg/encoder.ex
+++ b/lib/membrane_h264_ffmpeg/encoder.ex
@@ -12,7 +12,6 @@ defmodule Membrane.H264.FFmpeg.Encoder do
   Please check `t:t/0` for available options.
   """
   use Membrane.Filter
-  use Bunch.Typespec
   alias __MODULE__.Native
   alias Membrane.Buffer
   alias Membrane.H264
@@ -30,18 +29,17 @@ defmodule Membrane.H264.FFmpeg.Encoder do
 
   @default_crf 23
 
-  @list_type presets :: [
-               :ultrafast,
-               :superfast,
-               :veryfast,
-               :faster,
-               :fast,
-               :medium,
-               :slow,
-               :slower,
-               :veryslow,
-               :placebo
-             ]
+  @type preset() ::
+          :ultrafast
+          | :superfast
+          | :veryfast
+          | :faster
+          | :fast
+          | :medium
+          | :slow
+          | :slower
+          | :veryslow
+          | :placebo
 
   def_options crf: [
                 description: """
@@ -62,7 +60,7 @@ defmodule Membrane.H264.FFmpeg.Encoder do
                 same quality can be achieved.
                 """,
                 type: :atom,
-                spec: presets(),
+                spec: preset(),
                 default: :medium
               ],
               profile: [

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.H264.FFmpeg.Plugin.MixProject do
   use Mix.Project
 
-  @version "0.22.0"
+  @version "0.23.0"
   @github_url "https://github.com/membraneframework/membrane_h264_ffmpeg_plugin"
 
   def project do
@@ -38,7 +38,7 @@ defmodule Membrane.H264.FFmpeg.Plugin.MixProject do
 
   defp deps do
     [
-      {:bunch, "~> 1.3.0"},
+      {:bunch, "~> 1.4"},
       {:unifex, "~> 1.0"},
       {:membrane_core, "~> 0.10.0"},
       {:membrane_common_c, "~> 0.13.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.H264.FFmpeg.Plugin.MixProject do
   use Mix.Project
 
-  @version "0.23.0"
+  @version "0.22.1"
   @github_url "https://github.com/membraneframework/membrane_h264_ffmpeg_plugin"
 
   def project do
@@ -38,7 +38,7 @@ defmodule Membrane.H264.FFmpeg.Plugin.MixProject do
 
   defp deps do
     [
-      {:bunch, "~> 1.4"},
+      {:bunch, "~> 1.3"},
       {:unifex, "~> 1.0"},
       {:membrane_core, "~> 0.10.0"},
       {:membrane_common_c, "~> 0.13.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "bunch": {:hex, :bunch, "1.3.1", "f8fe80042f9eb474ef2801ae2c9372f9b13d11e7053265dcfc24b9d912e3750b", [:mix], [], "hexpm", "00e21b16ff9bb698b728a01a2fc4b3bf7fc0e87c4bb9c6e4a442324aa8c5e567"},
+  "bunch": {:hex, :bunch, "1.4.0", "ba6dc15b346498f4f1be602f505e341ecb2cdc32c1bccb3865fcc3d1f834e987", [:mix], [], "hexpm", "a6e5cff50be7e8fad7d4875bb890abb80d4bcfcdd76553ef29dc978dabd25e85"},
   "bunch_native": {:hex, :bunch_native, "0.5.0", "8ac1536789a597599c10b652e0b526d8833348c19e4739a0759a2bedfd924e63", [:mix], [{:bundlex, "~> 1.0", [hex: :bundlex, repo: "hexpm", optional: false]}], "hexpm", "24190c760e32b23b36edeb2dc4852515c7c5b3b8675b1a864e0715bdd1c8f80d"},
   "bundlex": {:hex, :bundlex, "1.0.0", "358c26a6c027359c6935dcd0716b68736b7604599d376c4e1ac17c6618ef6771", [:mix], [{:bunch, "~> 1.0", [hex: :bunch, repo: "hexpm", optional: false]}, {:qex, "~> 0.5", [hex: :qex, repo: "hexpm", optional: false]}, {:secure_random, "~> 0.5", [hex: :secure_random, repo: "hexpm", optional: false]}], "hexpm", "09b4a0c597a31e6e7ce8e103b94f19539bb2279f5966a3d6d46dcd32a5b6fd44"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "bunch": {:hex, :bunch, "1.4.0", "ba6dc15b346498f4f1be602f505e341ecb2cdc32c1bccb3865fcc3d1f834e987", [:mix], [], "hexpm", "a6e5cff50be7e8fad7d4875bb890abb80d4bcfcdd76553ef29dc978dabd25e85"},
+  "bunch": {:hex, :bunch, "1.4.1", "96176220b2024f715e9e85051f18ee98bbb42be77728a0165cdc3c01c87e483b", [:mix], [], "hexpm", "ff0bb584267f32a1541e7299fefe22a185e269b4081983bd6c5b0d56369f9037"},
   "bunch_native": {:hex, :bunch_native, "0.5.0", "8ac1536789a597599c10b652e0b526d8833348c19e4739a0759a2bedfd924e63", [:mix], [{:bundlex, "~> 1.0", [hex: :bundlex, repo: "hexpm", optional: false]}], "hexpm", "24190c760e32b23b36edeb2dc4852515c7c5b3b8675b1a864e0715bdd1c8f80d"},
   "bundlex": {:hex, :bundlex, "1.0.0", "358c26a6c027359c6935dcd0716b68736b7604599d376c4e1ac17c6618ef6771", [:mix], [{:bunch, "~> 1.0", [hex: :bunch, repo: "hexpm", optional: false]}, {:qex, "~> 0.5", [hex: :qex, repo: "hexpm", optional: false]}, {:secure_random, "~> 0.5", [hex: :secure_random, repo: "hexpm", optional: false]}], "hexpm", "09b4a0c597a31e6e7ce8e103b94f19539bb2279f5966a3d6d46dcd32a5b6fd44"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},


### PR DESCRIPTION
Locking bunch to  the patch instead of the minor makes it impossible to use both h264 ffmpeg plugin and bunch different than ~> 1.3.0.
I followed `membrane_core` and locked bunch to the minor.  