### PR TITLE
Add pts to encoder

### DIFF
--- a/c_src/membrane_h264_ffmpeg_plugin/decoder.c
+++ b/c_src/membrane_h264_ffmpeg_plugin/decoder.c
@@ -40,7 +40,8 @@ exit_create:
 }
 
 static int get_frames(UnifexEnv *env, AVPacket *pkt,
-                      UnifexPayload ***ret_frames, int64_t **best_effort_timestamps, int *max_frames,
+                      UnifexPayload ***ret_frames,
+                      int64_t **best_effort_timestamps, int *max_frames,
                       int *frame_cnt, int use_shm, State *state) {
   AVFrame *frame = av_frame_alloc();
   UnifexPayload **frames = unifex_alloc((*max_frames) * sizeof(*frames));
@@ -62,7 +63,8 @@ static int get_frames(UnifexEnv *env, AVPacket *pkt,
     if (*frame_cnt >= (*max_frames)) {
       *max_frames *= 2;
       frames = unifex_realloc(frames, (*max_frames) * sizeof(*frames));
-      timestamps = unifex_realloc(timestamps, (*max_frames) * sizeof(*timestamps));
+      timestamps =
+          unifex_realloc(timestamps, (*max_frames) * sizeof(*timestamps));
     }
 
     size_t payload_size = av_image_get_buffer_size(
@@ -96,7 +98,8 @@ exit_get_frames:
   return ret;
 }
 
-UNIFEX_TERM decode(UnifexEnv *env, UnifexPayload *payload, int64_t pts, int64_t dts, int use_shm, State *state) {
+UNIFEX_TERM decode(UnifexEnv *env, UnifexPayload *payload, int64_t pts,
+                   int64_t dts, int use_shm, State *state) {
   UNIFEX_TERM res_term;
   AVPacket *pkt = NULL;
   int max_frames = 16, frame_cnt = 0;
@@ -110,7 +113,8 @@ UNIFEX_TERM decode(UnifexEnv *env, UnifexPayload *payload, int64_t pts, int64_t 
 
   int ret = 0;
   if (pkt->size > 0) {
-    ret = get_frames(env, pkt, &out_frames, &pts_list, &max_frames, &frame_cnt, use_shm, state);
+    ret = get_frames(env, pkt, &out_frames, &pts_list, &max_frames, &frame_cnt,
+                     use_shm, state);
   }
 
   switch (ret) {
@@ -121,7 +125,8 @@ UNIFEX_TERM decode(UnifexEnv *env, UnifexPayload *payload, int64_t pts, int64_t 
     res_term = decode_result_error(env, "decode");
     break;
   default:
-    res_term = decode_result_ok(env, pts_list, frame_cnt, out_frames, frame_cnt);
+    res_term =
+        decode_result_ok(env, pts_list, frame_cnt, out_frames, frame_cnt);
   }
 
   if (out_frames != NULL) {
@@ -147,8 +152,9 @@ UNIFEX_TERM flush(UnifexEnv *env, int use_shm, State *state) {
   UnifexPayload **out_frames = NULL;
   int64_t *pts_list = NULL;
 
-  int ret = get_frames(env, NULL, &out_frames, &pts_list, &max_frames, &frame_cnt, use_shm, state);
-  
+  int ret = get_frames(env, NULL, &out_frames, &pts_list, &max_frames,
+                       &frame_cnt, use_shm, state);
+
   switch (ret) {
   case DECODER_SEND_PKT_ERROR:
     res_term = flush_result_error(env, "send_pkt");

--- a/c_src/membrane_h264_ffmpeg_plugin/encoder.c
+++ b/c_src/membrane_h264_ffmpeg_plugin/encoder.c
@@ -96,13 +96,15 @@ UNIFEX_TERM get_frame_size(UnifexEnv *env, State *state) {
 }
 
 static int get_frames(UnifexEnv *env, AVFrame *frame,
-                      UnifexPayload ***ret_frames, int64_t **dts_list, int64_t **pts_list,
-                      int *max_frames, int *frame_cnt, int use_shm,
-                      State *state) {
+                      UnifexPayload ***ret_frames, int64_t **dts_list,
+                      int64_t **pts_list, int *max_frames, int *frame_cnt,
+                      int use_shm, State *state) {
   AVPacket *pkt = av_packet_alloc();
   UnifexPayload **frames = unifex_alloc((*max_frames) * sizeof(*frames));
-  int64_t *timestamps_dts = unifex_alloc((*max_frames) * sizeof(*timestamps_dts));
-  int64_t *timestamps_pts = unifex_alloc((*max_frames) * sizeof(*timestamps_pts));
+  int64_t *decoding_ts =
+      unifex_alloc((*max_frames) * sizeof(*decoding_ts));
+  int64_t *presentation_ts =
+      unifex_alloc((*max_frames) * sizeof(*presentation_ts));
 
   int ret = avcodec_send_frame(state->codec_ctx, frame);
   if (ret < 0) {
@@ -120,14 +122,14 @@ static int get_frames(UnifexEnv *env, AVFrame *frame,
     if (*frame_cnt >= (*max_frames)) {
       *max_frames *= 2;
       frames = unifex_realloc(frames, (*max_frames) * sizeof(*frames));
-      timestamps_dts =
-          unifex_realloc(timestamps_dts, (*max_frames) * sizeof(*timestamps_dts));
-      timestamps_pts =
-          unifex_realloc(timestamps_pts, (*max_frames) * sizeof(*timestamps_pts));
+      decoding_ts = unifex_realloc(decoding_ts,
+                                      (*max_frames) * sizeof(*decoding_ts));
+      presentation_ts = unifex_realloc(presentation_ts,
+                                      (*max_frames) * sizeof(*presentation_ts));
     }
 
-    timestamps_dts[*frame_cnt] = pkt->dts;
-    timestamps_pts[*frame_cnt] = pkt->pts;
+    decoding_ts[*frame_cnt] = pkt->dts;
+    presentation_ts[*frame_cnt] = pkt->pts;
     frames[*frame_cnt] = unifex_alloc(sizeof(UnifexPayload));
     UnifexPayloadType payload_type;
     if (use_shm) {
@@ -144,8 +146,8 @@ static int get_frames(UnifexEnv *env, AVFrame *frame,
   ret = 0;
 exit_get_frames:
   *ret_frames = frames;
-  *dts_list = timestamps_dts;
-  *pts_list = timestamps_pts;
+  *dts_list = decoding_ts;
+  *pts_list = presentation_ts;
   av_packet_free(&pkt);
   return ret;
 }
@@ -173,8 +175,8 @@ UNIFEX_TERM encode(UnifexEnv *env, UnifexPayload *payload, int64_t pts,
   }
   state->last_pts = frame->pts;
 
-  res = get_frames(env, frame, &out_frames, &dts_list, &pts_list, &max_frames, &frame_cnt,
-                   use_shm, state);
+  res = get_frames(env, frame, &out_frames, &dts_list, &pts_list, &max_frames,
+                   &frame_cnt, use_shm, state);
 
   switch (res) {
   case ENCODER_SEND_FRAME_ERROR:
@@ -184,8 +186,8 @@ UNIFEX_TERM encode(UnifexEnv *env, UnifexPayload *payload, int64_t pts,
     res_term = encode_result_error(env, "encode");
     break;
   default:
-    res_term =
-        encode_result_ok(env, dts_list, frame_cnt, pts_list, frame_cnt, out_frames, frame_cnt);
+    res_term = encode_result_ok(env, dts_list, frame_cnt, pts_list, frame_cnt,
+                                out_frames, frame_cnt);
   }
   if (out_frames != NULL) {
     for (int i = 0; i < frame_cnt; i++) {
@@ -210,8 +212,8 @@ UNIFEX_TERM flush(UnifexEnv *env, int use_shm, State *state) {
   int64_t *dts_list = NULL;
   int64_t *pts_list = NULL;
 
-  int res = get_frames(env, NULL, &out_frames, &dts_list, &pts_list, &max_frames,
-                       &frame_cnt, use_shm, state);
+  int res = get_frames(env, NULL, &out_frames, &dts_list, &pts_list,
+                       &max_frames, &frame_cnt, use_shm, state);
   switch (res) {
   case ENCODER_SEND_FRAME_ERROR:
     res_term = encode_result_error(env, "send_frame");
@@ -220,8 +222,8 @@ UNIFEX_TERM flush(UnifexEnv *env, int use_shm, State *state) {
     res_term = encode_result_error(env, "encode");
     break;
   default:
-    res_term =
-        encode_result_ok(env, dts_list, frame_cnt, pts_list, frame_cnt, out_frames, frame_cnt);
+    res_term = encode_result_ok(env, dts_list, frame_cnt, pts_list, frame_cnt,
+                                out_frames, frame_cnt);
   }
 
   if (out_frames != NULL) {

--- a/c_src/membrane_h264_ffmpeg_plugin/encoder.c
+++ b/c_src/membrane_h264_ffmpeg_plugin/encoder.c
@@ -96,12 +96,13 @@ UNIFEX_TERM get_frame_size(UnifexEnv *env, State *state) {
 }
 
 static int get_frames(UnifexEnv *env, AVFrame *frame,
-                      UnifexPayload ***ret_frames, int64_t **dts_list,
+                      UnifexPayload ***ret_frames, int64_t **dts_list, int64_t **pts_list,
                       int *max_frames, int *frame_cnt, int use_shm,
                       State *state) {
   AVPacket *pkt = av_packet_alloc();
   UnifexPayload **frames = unifex_alloc((*max_frames) * sizeof(*frames));
-  int64_t *timestamps = unifex_alloc((*max_frames) * sizeof(*timestamps));
+  int64_t *timestamps_dts = unifex_alloc((*max_frames) * sizeof(*timestamps_dts));
+  int64_t *timestamps_pts = unifex_alloc((*max_frames) * sizeof(*timestamps_pts));
 
   int ret = avcodec_send_frame(state->codec_ctx, frame);
   if (ret < 0) {
@@ -119,11 +120,14 @@ static int get_frames(UnifexEnv *env, AVFrame *frame,
     if (*frame_cnt >= (*max_frames)) {
       *max_frames *= 2;
       frames = unifex_realloc(frames, (*max_frames) * sizeof(*frames));
-      timestamps =
-          unifex_realloc(timestamps, (*max_frames) * sizeof(*timestamps));
+      timestamps_dts =
+          unifex_realloc(timestamps_dts, (*max_frames) * sizeof(*timestamps_dts));
+      timestamps_pts =
+          unifex_realloc(timestamps_pts, (*max_frames) * sizeof(*timestamps_pts));
     }
 
-    timestamps[*frame_cnt] = pkt->dts;
+    timestamps_dts[*frame_cnt] = pkt->dts;
+    timestamps_pts[*frame_cnt] = pkt->pts;
     frames[*frame_cnt] = unifex_alloc(sizeof(UnifexPayload));
     UnifexPayloadType payload_type;
     if (use_shm) {
@@ -140,7 +144,8 @@ static int get_frames(UnifexEnv *env, AVFrame *frame,
   ret = 0;
 exit_get_frames:
   *ret_frames = frames;
-  *dts_list = timestamps;
+  *dts_list = timestamps_dts;
+  *pts_list = timestamps_pts;
   av_packet_free(&pkt);
   return ret;
 }
@@ -152,6 +157,7 @@ UNIFEX_TERM encode(UnifexEnv *env, UnifexPayload *payload, int64_t pts,
   int max_frames = 16, frame_cnt = 0;
   UnifexPayload **out_frames = NULL;
   int64_t *dts_list = NULL;
+  int64_t *pts_list = NULL;
 
   AVFrame *frame = av_frame_alloc();
   frame->format = state->codec_ctx->pix_fmt;
@@ -167,7 +173,7 @@ UNIFEX_TERM encode(UnifexEnv *env, UnifexPayload *payload, int64_t pts,
   }
   state->last_pts = frame->pts;
 
-  res = get_frames(env, frame, &out_frames, &dts_list, &max_frames, &frame_cnt,
+  res = get_frames(env, frame, &out_frames, &dts_list, &pts_list, &max_frames, &frame_cnt,
                    use_shm, state);
 
   switch (res) {
@@ -179,7 +185,7 @@ UNIFEX_TERM encode(UnifexEnv *env, UnifexPayload *payload, int64_t pts,
     break;
   default:
     res_term =
-        encode_result_ok(env, dts_list, frame_cnt, out_frames, frame_cnt);
+        encode_result_ok(env, dts_list, frame_cnt, pts_list, frame_cnt, out_frames, frame_cnt);
   }
   if (out_frames != NULL) {
     for (int i = 0; i < frame_cnt; i++) {
@@ -202,8 +208,9 @@ UNIFEX_TERM flush(UnifexEnv *env, int use_shm, State *state) {
   int max_frames = 16, frame_cnt = 0;
   UnifexPayload **out_frames = NULL;
   int64_t *dts_list = NULL;
+  int64_t *pts_list = NULL;
 
-  int res = get_frames(env, NULL, &out_frames, &dts_list, &max_frames,
+  int res = get_frames(env, NULL, &out_frames, &dts_list, &pts_list, &max_frames,
                        &frame_cnt, use_shm, state);
   switch (res) {
   case ENCODER_SEND_FRAME_ERROR:
@@ -214,7 +221,7 @@ UNIFEX_TERM flush(UnifexEnv *env, int use_shm, State *state) {
     break;
   default:
     res_term =
-        encode_result_ok(env, dts_list, frame_cnt, out_frames, frame_cnt);
+        encode_result_ok(env, dts_list, frame_cnt, pts_list, frame_cnt, out_frames, frame_cnt);
   }
 
   if (out_frames != NULL) {

--- a/c_src/membrane_h264_ffmpeg_plugin/encoder.spec.exs
+++ b/c_src/membrane_h264_ffmpeg_plugin/encoder.spec.exs
@@ -18,10 +18,11 @@ spec create(
 spec get_frame_size(state) :: {:ok :: label, frame_size :: int} | {:error :: label}
 
 spec encode(payload, pts :: int64, use_shm :: bool, state) ::
-       {:ok :: label, dts_list :: [int64], [payload]} | {:error :: label, reason :: atom}
+       {:ok :: label, dts_list :: [int64], pts_list :: [int64], [payload]}
+       | {:error :: label, reason :: atom}
 
 spec flush(use_shm :: bool, state) ::
-       {:ok :: label, dts_list :: [int64], frames :: [payload]}
+       {:ok :: label, dts_list :: [int64], pts_list :: [int64], frames :: [payload]}
        | {:error :: label, reason :: atom}
 
 dirty :cpu, flush: 1, encode: 3

--- a/lib/membrane_h264_ffmpeg/common.ex
+++ b/lib/membrane_h264_ffmpeg/common.ex
@@ -2,7 +2,7 @@ defmodule Membrane.H264.FFmpeg.Common do
   @moduledoc false
   use Ratio
   @h264_time_base 90_000
-
+  @no_pts -9_223_372_036_854_775_808
   @doc """
   Converts time in membrane time base (1 [ns]) to h264 time base (1/90_000 [s])
   """
@@ -14,7 +14,9 @@ defmodule Membrane.H264.FFmpeg.Common do
   @doc """
   Converts time from h264 time base (1/90_000 [s]) to membrane time base (1 [ns])
   """
-  @spec to_membrane_time_base_truncated(number | Ratio.t()) :: integer
+  @spec to_membrane_time_base_truncated(number | Ratio.t()) :: integer | nil
+  def to_membrane_time_base_truncated(@no_pts), do: nil
+
   def to_membrane_time_base_truncated(timestamp) do
     (timestamp * Membrane.Time.second() / @h264_time_base) |> Ratio.trunc()
   end

--- a/lib/membrane_h264_ffmpeg/common.ex
+++ b/lib/membrane_h264_ffmpeg/common.ex
@@ -3,10 +3,13 @@ defmodule Membrane.H264.FFmpeg.Common do
   use Ratio
   @h264_time_base 90_000
   @no_pts -9_223_372_036_854_775_808
+
   @doc """
   Converts time in membrane time base (1 [ns]) to h264 time base (1/90_000 [s])
   """
-  @spec to_h264_time_base_truncated(number | Ratio.t()) :: integer
+  @spec to_h264_time_base_truncated(number | Ratio.t() | nil) :: integer
+  def to_h264_time_base_truncated(nil), do: @no_pts
+
   def to_h264_time_base_truncated(timestamp) do
     (timestamp * @h264_time_base / Membrane.Time.second()) |> Ratio.trunc()
   end

--- a/lib/membrane_h264_ffmpeg/decoder.ex
+++ b/lib/membrane_h264_ffmpeg/decoder.ex
@@ -16,8 +16,6 @@ defmodule Membrane.H264.FFmpeg.Decoder do
   alias Membrane.H264.FFmpeg.Common
   alias Membrane.RawVideo
 
-  @no_pts -9_223_372_036_854_775_808
-
   def_options use_shm?: [
                 type: :boolean,
                 desciption:
@@ -55,8 +53,8 @@ defmodule Membrane.H264.FFmpeg.Decoder do
   def handle_process(:input, buffer, ctx, state) do
     %{decoder_ref: decoder_ref, use_shm?: use_shm?} = state
 
-    dts = if(buffer.dts, do: Common.to_h264_time_base_truncated(buffer.dts), else: @no_pts)
-    pts = if(buffer.pts, do: Common.to_h264_time_base_truncated(buffer.pts), else: @no_pts)
+    dts = Common.to_h264_time_base_truncated(buffer.dts)
+    pts = Common.to_h264_time_base_truncated(buffer.pts)
 
     case Native.decode(
            buffer.payload,

--- a/lib/membrane_h264_ffmpeg/encoder.ex
+++ b/lib/membrane_h264_ffmpeg/encoder.ex
@@ -18,8 +18,6 @@ defmodule Membrane.H264.FFmpeg.Encoder do
   alias Membrane.H264.FFmpeg.Common
   alias Membrane.RawVideo
 
-  @no_pts -9_223_372_036_854_775_808
-
   def_input_pad :input,
     demand_mode: :auto,
     demand_unit: :buffers,
@@ -106,7 +104,7 @@ defmodule Membrane.H264.FFmpeg.Encoder do
   @impl true
   def handle_process(:input, buffer, _ctx, state) do
     %{encoder_ref: encoder_ref, use_shm?: use_shm?} = state
-    pts = if is_nil(buffer.pts), do: @no_pts, else: Common.to_h264_time_base_truncated(buffer.pts)
+    pts = Common.to_h264_time_base_truncated(buffer.pts)
 
     case Native.encode(
            buffer.payload,

--- a/test/encoder/encoder_native_test.exs
+++ b/test/encoder/encoder_native_test.exs
@@ -8,7 +8,7 @@ defmodule Encoder.NativeTest do
     assert {:ok, file} = File.read(in_path)
     assert {:ok, ref} = Enc.create(320, 240, :I420, :fast, :high, -1, -1, 30, 1, 23)
     assert <<frame::bytes-size(115_200), _tail::binary>> = file
-    assert {:ok, _dts_list, _frames} = Enc.encode(frame, 0, false, ref)
-    assert {:ok, [_dts], [_frame]} = Enc.flush(false, ref)
+    assert {:ok, _dts_list, _pts_list, _frames} = Enc.encode(frame, 0, false, ref)
+    assert {:ok, [_dts], [_pts], [_frame]} = Enc.flush(false, ref)
   end
 end

--- a/test/encoder/encoder_native_test.exs
+++ b/test/encoder/encoder_native_test.exs
@@ -1,14 +1,29 @@
 defmodule Encoder.NativeTest do
   use ExUnit.Case, async: true
+
+  import Membrane.Time
+
+  alias Membrane.H264.FFmpeg.Common
   alias Membrane.H264.FFmpeg.Encoder.Native, as: Enc
 
   test "Encode 1 240p frame" do
     in_path = "../fixtures/reference-100-240p.raw" |> Path.expand(__DIR__)
 
     assert {:ok, file} = File.read(in_path)
-    assert {:ok, ref} = Enc.create(320, 240, :I420, :fast, :high, -1, -1, 30, 1, 23)
+    assert {:ok, ref} = Enc.create(320, 240, :I420, :fast, :high, -1, -1, 1, 1, 23)
     assert <<frame::bytes-size(115_200), _tail::binary>> = file
-    assert {:ok, _dts_list, _pts_list, _frames} = Enc.encode(frame, 0, false, ref)
-    assert {:ok, [_dts], [_pts], [_frame]} = Enc.flush(false, ref)
+
+    Enum.each(
+      0..4,
+      &Enc.encode(frame, Common.to_h264_time_base_truncated(seconds(&1)), false, ref)
+    )
+
+    assert {:ok, _dts_list, _pts, _frames} =
+             Enc.encode(frame, Common.to_h264_time_base_truncated(seconds(5)), false, ref)
+
+    assert {:ok, _dts, pts, _frames} = Enc.flush(false, ref)
+
+    assert Enum.sort(Enum.map(pts, &Common.to_membrane_time_base_truncated(&1))) ==
+             Enum.map(0..5, &seconds(&1))
   end
 end


### PR DESCRIPTION
Right now encoder adds only dts to buffers. Pts should be added always especially when B-frames are included.