### PR TITLE
Fix last sample's dts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation is available at [HexDocs](https://hexdocs.pm/membrane_h264_ffmpeg_
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-  {:membrane_h264_ffmpeg_plugin, "~> 0.25.0"}
+  {:membrane_h264_ffmpeg_plugin, "~> 0.25.1"}
 ```
 
 You also need to have [ffmpeg](https://www.ffmpeg.org) libraries installed in your system.

--- a/c_src/membrane_h264_ffmpeg_plugin/parser.c
+++ b/c_src/membrane_h264_ffmpeg_plugin/parser.c
@@ -222,7 +222,7 @@ UNIFEX_TERM flush(UnifexEnv *env, State *state) {
   update_last_frame_number(picture_order_number, state);
 
   int presentation_order_number = picture_order_number + state->poc_offset;
-  int decoding_order_number = state->last_frame_number + 1;
+  int decoding_order_number = state->last_frame_number;
 
   if (resolution_changed(res, state)) {
     res.width = state->parser_ctx->width;

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.H264.FFmpeg.Plugin.MixProject do
   use Mix.Project
 
-  @version "0.25.0"
+  @version "0.25.1"
   @github_url "https://github.com/membraneframework/membrane_h264_ffmpeg_plugin"
 
   def project do


### PR DESCRIPTION
There have been some changes introduced in #69 regarding the fix of pts of the last buffer. While this fixed the pts it also broke the last dts by incrementing it by an excessive `1`. In case of baseline stream where dts and pts values should be the same this corrupted the last buffer therefore tools like ffmpeg were likely to error out (as the last dts was greater than the last pts).
