### PR TITLE
Download precompiled ffmpeg for arm64

### DIFF
--- a/bundlex.exs
+++ b/bundlex.exs
@@ -6,6 +6,10 @@ defmodule Membrane.H264.FFmpeg.BundlexProject do
       "https://github.com/membraneframework-precompiled/precompiled_ffmpeg/releases/latest/download/ffmpeg"
 
     case Bundlex.get_target() do
+      %{os: "linux", architecture: "aarch64"} ->
+        {:precompiled,
+         "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n6.0-latest-linuxarm64-gpl-shared-6.0.tar.xz"}
+
       %{os: "linux"} ->
         {:precompiled,
          "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n6.0-latest-linux64-gpl-shared-6.0.tar.xz"}

--- a/bundlex.exs
+++ b/bundlex.exs
@@ -6,7 +6,7 @@ defmodule Membrane.H264.FFmpeg.BundlexProject do
       "https://github.com/membraneframework-precompiled/precompiled_ffmpeg/releases/latest/download/ffmpeg"
 
     case Bundlex.get_target() do
-      %{os: "linux", architecture: "aarch64"} ->
+      %{architecture: "aarch64", os: "linux"} ->
         {:precompiled,
          "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n6.0-latest-linuxarm64-gpl-shared-6.0.tar.xz"}
 


### PR DESCRIPTION
Compiling this plugin on `arm64` machines downloads the wrong pre-compiled version and the building fails if `ffmpeg` is not installed on the host.

Tested on `rpi 4`