### PR TITLE
Handle keyframe request it in the encoder and use x264 defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Note: `Membrane.H264.FFmpeg.Parser` has been removed. Now you can use our pure E
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-{:membrane_h264_ffmpeg_plugin, "~> 0.31.8"}
+{:membrane_h264_ffmpeg_plugin, "~> 0.32.0"}
 ```
 
 This package depends on the [ffmpeg](https://www.ffmpeg.org) libraries. The precompiled builds will be pulled and linked automatically. However, should there be any problems, consider installing it manually.

--- a/c_src/membrane_h264_ffmpeg_plugin/encoder.c
+++ b/c_src/membrane_h264_ffmpeg_plugin/encoder.c
@@ -134,6 +134,11 @@ UNIFEX_TERM create(UnifexEnv *env, int width, int height, char *pix_fmt,
   av_dict_set_int(&params, "crf", crf, 0);
   av_dict_set_int(&params, "sc_threshold", sc_threshold, 0);
 
+  if (avcodec_open2(state->codec_ctx, codec, &params) < 0) {
+    res = create_result_error(env, "codec_open");
+    goto exit_create;
+  }
+
   res = create_result_ok(env, state);
 exit_create:
   unifex_release_state(env, state);

--- a/c_src/membrane_h264_ffmpeg_plugin/encoder.c
+++ b/c_src/membrane_h264_ffmpeg_plugin/encoder.c
@@ -72,6 +72,16 @@ UNIFEX_TERM create(UnifexEnv *env, int width, int height, char *pix_fmt,
 
   av_dict_set_int(&params, "sc_threshold", sc_threshold, 0);
 
+  av_dict_set_int(&params, "qcomp", "0.6", 0);
+  av_dict_set_int(&params, "me_range", "16", 0);
+  av_dict_set_int(&params, "qdiff", "4", 0);
+  av_dict_set_int(&params, "qmin", "0", 0);
+  av_dict_set_int(&params, "qmax", "69", 0);
+  av_dict_set_int(&params, "i_qfactor", "1.4", 0);
+  av_dict_set_int(&params, "f_pb_factor", "1.3", 0);
+  av_dict_set_int(&params, "partitions", "p8x8,b8x8,i8x8,i4x4", 0);
+  av_dict_set_int(&params, "subq", "2", 0);
+
   if (avcodec_open2(state->codec_ctx, codec, &params) < 0) {
     res = create_result_error(env, "codec_open");
     goto exit_create;

--- a/c_src/membrane_h264_ffmpeg_plugin/encoder.c
+++ b/c_src/membrane_h264_ffmpeg_plugin/encoder.c
@@ -72,15 +72,15 @@ UNIFEX_TERM create(UnifexEnv *env, int width, int height, char *pix_fmt,
 
   av_dict_set_int(&params, "sc_threshold", sc_threshold, 0);
 
-  av_dict_set_int(&params, "qcomp", "0.6", 0);
-  av_dict_set_int(&params, "me_range", "16", 0);
-  av_dict_set_int(&params, "qdiff", "4", 0);
-  av_dict_set_int(&params, "qmin", "0", 0);
-  av_dict_set_int(&params, "qmax", "69", 0);
-  av_dict_set_int(&params, "i_qfactor", "1.4", 0);
-  av_dict_set_int(&params, "f_pb_factor", "1.3", 0);
-  av_dict_set_int(&params, "partitions", "p8x8,b8x8,i8x8,i4x4", 0);
-  av_dict_set_int(&params, "subq", "2", 0);
+  av_dict_set(&params, "qcomp", "0.6", 0);
+  av_dict_set(&params, "me_range", "16", 0);
+  av_dict_set(&params, "qdiff", "4", 0);
+  av_dict_set(&params, "qmin", "0", 0);
+  av_dict_set(&params, "qmax", "69", 0);
+  av_dict_set(&params, "i_qfactor", "1.4", 0);
+  av_dict_set(&params, "f_pb_factor", "1.3", 0);
+  av_dict_set(&params, "partitions", "p8x8,b8x8,i8x8,i4x4", 0);
+  av_dict_set(&params, "subq", "2", 0);
 
   if (avcodec_open2(state->codec_ctx, codec, &params) < 0) {
     res = create_result_error(env, "codec_open");

--- a/c_src/membrane_h264_ffmpeg_plugin/encoder.c
+++ b/c_src/membrane_h264_ffmpeg_plugin/encoder.c
@@ -64,8 +64,6 @@ UNIFEX_TERM create(UnifexEnv *env, int width, int height, char *pix_fmt,
     av_dict_set(&params, "profile", profile, 0);
   }
 
-//  state->codec_ctx->profile = FF_PROFILE_H264_BASELINE;
-
   if (strcmp("nil", tune) != 0) {
     av_dict_set(&params, "tune", tune, 0);
   }

--- a/c_src/membrane_h264_ffmpeg_plugin/encoder.c
+++ b/c_src/membrane_h264_ffmpeg_plugin/encoder.c
@@ -64,6 +64,8 @@ UNIFEX_TERM create(UnifexEnv *env, int width, int height, char *pix_fmt,
     av_dict_set(&params, "profile", profile, 0);
   }
 
+//  state->codec_ctx->profile = FF_PROFILE_H264_BASELINE;
+
   if (strcmp("nil", tune) != 0) {
     av_dict_set(&params, "tune", tune, 0);
   }
@@ -153,7 +155,7 @@ exit_get_frames:
 }
 
 UNIFEX_TERM encode(UnifexEnv *env, UnifexPayload *payload, int64_t pts,
-                   int use_shm, State *state) {
+                   int use_shm, int keyframe_requested, State *state) {
   UNIFEX_TERM res_term;
   int res = 0;
   int max_frames = 16, frame_cnt = 0;
@@ -165,6 +167,9 @@ UNIFEX_TERM encode(UnifexEnv *env, UnifexPayload *payload, int64_t pts,
   frame->format = state->codec_ctx->pix_fmt;
   frame->width = state->codec_ctx->width;
   frame->height = state->codec_ctx->height;
+  if(keyframe_requested) {
+    frame->pict_type = AV_PICTURE_TYPE_I;
+  }
   av_image_fill_arrays(frame->data, frame->linesize, payload->data,
                        frame->format, frame->width, frame->height, 1);
 

--- a/c_src/membrane_h264_ffmpeg_plugin/encoder.c
+++ b/c_src/membrane_h264_ffmpeg_plugin/encoder.c
@@ -8,6 +8,68 @@ void handle_destroy_state(UnifexEnv *env, State *state) {
   }
 }
 
+static void set_x264_defaults(AVDictionary **params, char* preset) {
+  // Override FFmpeg defaults from https://github.com/mirror/x264/blob/eaa68fad9e5d201d42fde51665f2d137ae96baf0/encoder/encoder.c#L674
+  av_dict_set(params, "me_range", "16", 0);
+  av_dict_set(params, "qdiff", "4", 0);
+  av_dict_set(params, "qmin", "0", 0);
+  av_dict_set(params, "qmax", "69", 0);
+  av_dict_set(params, "i_qfactor", "1.4", 0);
+  av_dict_set(params, "f_pb_factor", "1.3", 0);
+  
+  if (strcmp(preset, "ultrafast") == 0) 
+  {
+    av_dict_set(params, "partitions", "none", 0);
+    av_dict_set(params, "subq", "0", 0);
+  } 
+  else if (strcmp(preset, "superfast") == 0) 
+  {
+    av_dict_set(params, "partitions", "i8x8,i4x4", 0);
+    av_dict_set(params, "subq", "1", 0);
+  }
+  else if (strcmp(preset, "veryfast") == 0) 
+  {
+    av_dict_set(params, "partitions", "p8x8,b8x8,i8x8,i4x4", 0);
+    av_dict_set(params, "subq", "2", 0);
+  }
+  else if (strcmp(preset, "faster") == 0) 
+  {
+    av_dict_set(params, "partitions", "p8x8,b8x8,i8x8,i4x4", 0);
+    av_dict_set(params, "subq", "4", 0);
+  }
+  else if (strcmp(preset, "fast") == 0) 
+  {
+    av_dict_set(params, "partitions", "p8x8,b8x8,i8x8,i4x4", 0);
+    av_dict_set(params, "subq", "6", 0);
+  }
+  else if (strcmp(preset, "medium") == 0) 
+  {
+    av_dict_set(params, "partitions", "p8x8,b8x8,i8x8,i4x4", 0);
+    av_dict_set(params, "subq", "7", 0);
+  }
+  else if (strcmp(preset, "slow") == 0) 
+  {
+    av_dict_set(params, "partitions", "all", 0);
+    av_dict_set(params, "subq", "8", 0);
+  } 
+  else if (strcmp(preset, "slower") == 0) 
+  {
+    av_dict_set(params, "partitions", "all", 0);
+    av_dict_set(params, "subq", "9", 0);
+  } 
+  else if (strcmp(preset, "veryslow") == 0) 
+  {
+    av_dict_set(params, "partitions", "all", 0);
+    av_dict_set(params, "subq", "10", 0);
+  } 
+  else if (strcmp(preset, "placebo") == 0) 
+  {
+    av_dict_set(params, "partitions", "all", 0);
+    av_dict_set(params, "subq", "11", 0);
+  } 
+}
+
+
 UNIFEX_TERM create(UnifexEnv *env, int width, int height, char *pix_fmt,
                    char *preset, char *tune, char *profile, int max_b_frames, int gop_size,
                    int timebase_num, int timebase_den, int crf, int sc_threshold) {
@@ -237,65 +299,4 @@ UNIFEX_TERM flush(UnifexEnv *env, int use_shm, State *state) {
     unifex_free(dts_list);
   }
   return res_term;
-}
-
-static void set_x264_defaults(AVDictionary **params, char* preset) {
-  // Override FFmpeg defaults from https://github.com/mirror/x264/blob/eaa68fad9e5d201d42fde51665f2d137ae96baf0/encoder/encoder.c#L674
-  av_dict_set(params, "me_range", "16", 0);
-  av_dict_set(params, "qdiff", "4", 0);
-  av_dict_set(params, "qmin", "0", 0);
-  av_dict_set(params, "qmax", "69", 0);
-  av_dict_set(params, "i_qfactor", "1.4", 0);
-  av_dict_set(params, "f_pb_factor", "1.3", 0);
-  
-  if (strcmp(preset, "ultrafast") == 0) 
-  {
-    av_dict_set(params, "partitions", "none", 0);
-    av_dict_set(params, "subq", "0", 0);
-  } 
-  else if (strcmp(preset, "superfast") == 0) 
-  {
-    av_dict_set(params, "partitions", "i8x8,i4x4", 0);
-    av_dict_set(params, "subq", "1", 0);
-  }
-  else if (strcmp(preset, "veryfast") == 0) 
-  {
-    av_dict_set(params, "partitions", "p8x8,b8x8,i8x8,i4x4", 0);
-    av_dict_set(params, "subq", "2", 0);
-  }
-  else if (strcmp(preset, "faster") == 0) 
-  {
-    av_dict_set(params, "partitions", "p8x8,b8x8,i8x8,i4x4", 0);
-    av_dict_set(params, "subq", "4", 0);
-  }
-  else if (strcmp(preset, "fast") == 0) 
-  {
-    av_dict_set(params, "partitions", "p8x8,b8x8,i8x8,i4x4", 0);
-    av_dict_set(params, "subq", "6", 0);
-  }
-  else if (strcmp(preset, "medium") == 0) 
-  {
-    av_dict_set(params, "partitions", "p8x8,b8x8,i8x8,i4x4", 0);
-    av_dict_set(params, "subq", "7", 0);
-  }
-  else if (strcmp(preset, "slow") == 0) 
-  {
-    av_dict_set(params, "partitions", "all", 0);
-    av_dict_set(params, "subq", "8", 0);
-  } 
-  else if (strcmp(preset, "slower") == 0) 
-  {
-    av_dict_set(params, "partitions", "all", 0);
-    av_dict_set(params, "subq", "9", 0);
-  } 
-  else if (strcmp(preset, "veryslow") == 0) 
-  {
-    av_dict_set(params, "partitions", "all", 0);
-    av_dict_set(params, "subq", "10", 0);
-  } 
-  else if (strcmp(preset, "placebo") == 0) 
-  {
-    av_dict_set(params, "partitions", "all", 0);
-    av_dict_set(params, "subq", "11", 0);
-  } 
 }

--- a/c_src/membrane_h264_ffmpeg_plugin/encoder.spec.exs
+++ b/c_src/membrane_h264_ffmpeg_plugin/encoder.spec.exs
@@ -19,7 +19,7 @@ spec create(
 
 spec get_frame_size(state) :: {:ok :: label, frame_size :: int} | {:error :: label}
 
-spec encode(payload, pts :: int64, use_shm :: bool, state) ::
+spec encode(payload, pts :: int64, use_shm :: bool, keyframe_requested :: bool, state) ::
        {:ok :: label, dts_list :: [int64], pts_list :: [int64], [payload]}
        | {:error :: label, reason :: atom}
 

--- a/lib/membrane_h264_ffmpeg/encoder.ex
+++ b/lib/membrane_h264_ffmpeg/encoder.ex
@@ -128,6 +128,7 @@ defmodule Membrane.H264.FFmpeg.Encoder do
     state =
       opts
       |> Map.put(:encoder_ref, nil)
+      |> Map.put(:keyframe_requested?, false)
 
     {[], state}
   end
@@ -141,12 +142,13 @@ defmodule Membrane.H264.FFmpeg.Encoder do
            buffer.payload,
            pts,
            use_shm?,
+           state.keyframe_requested?,
            encoder_ref
          ) do
       {:ok, dts_list, pts_list, frames} ->
         bufs = wrap_frames(dts_list, pts_list, frames)
 
-        {bufs, state}
+        {bufs, %{state | keyframe_requested?: false}}
 
       {:error, reason} ->
         raise "Native encoder failed to encode the payload: #{inspect(reason)}"
@@ -192,6 +194,21 @@ defmodule Membrane.H264.FFmpeg.Encoder do
     buffers = flush_encoder_if_exists(state)
     actions = buffers ++ [end_of_stream: :output]
     {actions, state}
+  end
+
+  @impl true
+  def handle_event(:input, event, _ctx, state) do
+    {[event: {:output, event}], state}
+  end
+
+  @impl true
+  def handle_event(:output, %Membrane.H264.FFmpeg.KeyframeRequestEvent{}, _ctx, state) do
+    {[], %{state | keyframe_requested?: true}}
+  end
+
+  @impl true
+  def handle_event(:output, event, _ctx, state) do
+    {[event: {:input, event}], state}
   end
 
   defp flush_encoder_if_exists(%{encoder_ref: nil}), do: []

--- a/lib/membrane_h264_ffmpeg/encoder.ex
+++ b/lib/membrane_h264_ffmpeg/encoder.ex
@@ -202,7 +202,7 @@ defmodule Membrane.H264.FFmpeg.Encoder do
   end
 
   @impl true
-  def handle_event(:output, %Membrane.H264.FFmpeg.KeyframeRequestEvent{}, _ctx, state) do
+  def handle_event(:output, %Membrane.KeyframeRequestEvent{}, _ctx, state) do
     {[], %{state | keyframe_requested?: true}}
   end
 

--- a/lib/membrane_h264_ffmpeg/keyframe_request_event.ex
+++ b/lib/membrane_h264_ffmpeg/keyframe_request_event.ex
@@ -1,5 +1,0 @@
-defmodule Membrane.H264.FFmpeg.KeyframeRequestEvent do
-  @moduledoc false
-  @derive Membrane.EventProtocol
-  defstruct []
-end

--- a/lib/membrane_h264_ffmpeg/keyframe_request_event.ex
+++ b/lib/membrane_h264_ffmpeg/keyframe_request_event.ex
@@ -1,0 +1,5 @@
+defmodule Membrane.H264.FFmpeg.KeyframeRequestEvent do
+  @moduledoc false
+  @derive Membrane.EventProtocol
+  defstruct []
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.H264.FFmpeg.Plugin.MixProject do
   use Mix.Project
 
-  @version "0.31.8"
+  @version "0.32.0"
   @github_url "https://github.com/membraneframework/membrane_h264_ffmpeg_plugin"
 
   def project do

--- a/test/encoder/encoder_native_test.exs
+++ b/test/encoder/encoder_native_test.exs
@@ -20,8 +20,9 @@ defmodule Encoder.NativeTest do
                  Enc.encode(
                    frame,
                    Common.to_h264_time_base_truncated(seconds(timestamp)),
-                   false,
-                   ref
+                   _use_shm? = false,
+                   _keyframe_requested? = false
+                   ref,
                  )
       end
     )

--- a/test/encoder/encoder_native_test.exs
+++ b/test/encoder/encoder_native_test.exs
@@ -21,8 +21,8 @@ defmodule Encoder.NativeTest do
                    frame,
                    Common.to_h264_time_base_truncated(seconds(timestamp)),
                    _use_shm? = false,
-                   _keyframe_requested? = false
-                   ref,
+                   _keyframe_requested? = false,
+                   ref
                  )
       end
     )


### PR DESCRIPTION
This PR:
* adds handling of `Membran.KeyframeRequestEvent`
* sets the default x264 parameters in the encoder instead of using FFmpeg default params
* bump to v0.32.0