### PR TITLE
Revoke setting of the timebase to 1us. Bump to v0.32.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Note: `Membrane.H264.FFmpeg.Parser` has been removed. Now you can use our pure E
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-{:membrane_h264_ffmpeg_plugin, "~> 0.32.1"}
+{:membrane_h264_ffmpeg_plugin, "~> 0.32.2"}
 ```
 
 This package depends on the [ffmpeg](https://www.ffmpeg.org) libraries. The precompiled builds will be pulled and linked automatically. However, should there be any problems, consider installing it manually.

--- a/c_src/membrane_h264_ffmpeg_plugin/encoder.c
+++ b/c_src/membrane_h264_ffmpeg_plugin/encoder.c
@@ -10,7 +10,6 @@ void handle_destroy_state(UnifexEnv *env, State *state) {
 
 static void set_x264_defaults(AVDictionary **params, char* preset) {
   // Override FFmpeg defaults from https://github.com/mirror/x264/blob/eaa68fad9e5d201d42fde51665f2d137ae96baf0/encoder/encoder.c#L674
-  av_dict_set(params, "time_base", "1/1000000", 0);
   av_dict_set(params, "qcomp", "0.6", 0);
   av_dict_set(params, "me_range", "16", 0);
   av_dict_set(params, "qdiff", "4", 0);

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.H264.FFmpeg.Plugin.MixProject do
   use Mix.Project
 
-  @version "0.32.1"
+  @version "0.32.2"
   @github_url "https://github.com/membraneframework/membrane_h264_ffmpeg_plugin"
 
   def project do


### PR DESCRIPTION
It turns out that setting the timebase to 1us causes some weird decoding failures with browser's decoders. That is why we have decided to revoke the original default setting of the `AVCodecContext::time_base` to `1/framerate`